### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -2,7 +2,7 @@
 
 const	dataWriter	= require(__dirname + '/dataWriter.js'),
 	intercom	= require('larvitutils').instances.intercom,
-	uuidLib	= require('node-uuid'),
+	uuidLib	= require('uuid'),
 	async	= require('async'),
 	log	= require('winston'),
 	db	= require('larvitdb');

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "larvitdb": "^1.2.5",
     "larvitdbmigration": "^1.3.3",
     "larvitutils": "^1.0.4",
-    "node-uuid": "^1.4.7",
     "to-utf-8": "^1.2.0",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0"
   }
 }

--- a/product.js
+++ b/product.js
@@ -7,7 +7,7 @@ const	EventEmitter	= require('events').EventEmitter,
 	intercom	= require('larvitutils').instances.intercom,
 	Products	= require(__dirname + '/products.js'),
 	helpers	= require(__dirname + '/helpers.js'),
-	uuidLib	= require('node-uuid'),
+	uuidLib	= require('uuid'),
 	async	= require('async'),
 	log	= require('winston');
 

--- a/test/00test.js
+++ b/test/00test.js
@@ -2,7 +2,7 @@
 
 const	uuidValidate	= require('uuid-validate'),
 	Intercom	= require('larvitamintercom'),
-	uuidLib	= require('node-uuid'),
+	uuidLib	= require('uuid'),
 	assert	= require('assert'),
 	lUtils	= require('larvitutils'),
 	async	= require('async'),


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.